### PR TITLE
deleting all files from a repo that are not out.tsv

### DIFF
--- a/Handler/DeleteSubmission.hs
+++ b/Handler/DeleteSubmission.hs
@@ -33,18 +33,23 @@ declareDeleteSubmissionApi = do
     let idSchema = toParamSchema (Proxy :: Proxy Int)
     response <- declareResponse (Proxy :: Proxy String)
 
-    pure $ mempty
-        & paths .~ fromList
-            [ ("/api/delete-submission/{submissionId}", mempty
-                & DS.post ?~ (mempty
-                & parameters .~ [ Inline $ mempty
+    pure $ mempty & paths .~ fromList
+        [
+            ( "/api/delete-submission/{submissionId}", mempty
+            & DS.post ?~ (mempty
+                & parameters .~
+                [
+                    Inline $ mempty
                     & name .~ "submissionId"
                     & required ?~ True
                     & schema .~ ParamOther (mempty
                         & in_ .~ ParamPath
-                        & paramSchema .~ idSchema)
+                        & paramSchema .~ idSchema
+                        )
                 ]
                 & produces ?~ MimeList ["application/json"]
                 & description ?~ "Deletes the submission by setting 'true' value in the 'deleted' field in 'Submission' table."
-                & at 200 ?~ Inline response ))
-            ]
+                & at 200 ?~ Inline response
+                )
+            )
+        ]

--- a/Handler/EditSubmissionV1.hs
+++ b/Handler/EditSubmissionV1.hs
@@ -51,7 +51,7 @@ postEditSubmission1R submissionId tagIdxsTxt newDescription = do
     where
         mkId x = toSqlKey $ fromIntegral (read (Data.Text.unpack x) :: Int)
         mkEntry x = SubmissionTag submissionId x Nothing
-        idFromEntity (Entity tagId tag) = tagId
+        idFromEntity (Entity tagId _) = tagId
 
 
 editSubmission1Api :: Swagger
@@ -66,35 +66,42 @@ declareEditSubmission1Api = do
         txtSchema = toParamSchema (Proxy :: Proxy Text)
     response <- declareResponse (Proxy :: Proxy ())
 
-    pure $ mempty
-        & paths .~ fromList [
-            ("/api/edit-submission/{submissionId}/{tagsIds}/{description}"
-            , mempty & DS.post ?~
-                ( mempty
+    pure $ mempty & paths .~ fromList
+        [
+            ("/api/edit-submission/{submissionId}/{tagsIds}/{description}", mempty
+            & DS.post ?~ (mempty
                 & parameters .~ 
-                    [ Inline $ mempty
-                        & name .~ "submissionId"
-                        & required ?~ True
-                        & description ?~ "Intiger, e.g.: 123"
-                        & schema .~ ParamOther (mempty
-                            & in_ .~ ParamPath
-                            & paramSchema .~ idSchema)
-                    , Inline $ mempty
-                        & name .~ "tagsIds"
-                        & description ?~ "Intigers separated with coma, e.g.: 1,2,3"
-                        & required ?~ True
-                        & schema .~ ParamOther (mempty
-                            & in_ .~ ParamPath
-                            & paramSchema .~ txtSchema)
-                    , Inline $ mempty
-                        & name .~ "description"
-                        & description ?~ "String, e.g.: simple description"
-                        & required ?~ True
-                        & schema .~ ParamOther (mempty
-                            & in_ .~ ParamPath
-                            & paramSchema .~ txtSchema)
-                    ]
+                [
+                    Inline $ mempty
+                    & name .~ "submissionId"
+                    & required ?~ True
+                    & description ?~ "Intiger, e.g.: 123"
+                    & schema .~ ParamOther (mempty
+                        & in_ .~ ParamPath
+                        & paramSchema .~ idSchema
+                        ),
+                    
+                    Inline $ mempty
+                    & name .~ "tagsIds"
+                    & description ?~ "Intigers separated with coma, e.g.: 1,2,3"
+                    & required ?~ True
+                    & schema .~ ParamOther (mempty
+                        & in_ .~ ParamPath
+                        & paramSchema .~ txtSchema
+                        ),
+
+                    Inline $ mempty
+                    & name .~ "description"
+                    & description ?~ "String, e.g.: simple description"
+                    & required ?~ True
+                    & schema .~ ParamOther (mempty
+                        & in_ .~ ParamPath
+                        & paramSchema .~ txtSchema
+                        )
+                ]
                 & produces ?~ MimeList ["application/json"]
                 & description ?~ "Edit submission description and tag fields."
-                & at 200 ?~ Inline response ))
-            ]
+                & at 200 ?~ Inline response
+                )
+            )
+        ]


### PR DESCRIPTION
Function _cloneRepo'_ in _Handler/Shared.hs_ got additional part: after renaming the temp directory for the cloned repository, all files from the directory are removed and only _out.tsv_ (and hidden files) are left. The structure of the directories is also left intact.